### PR TITLE
Fixes for premature exit from decoding

### DIFF
--- a/pngpread.c
+++ b/pngpread.c
@@ -830,7 +830,7 @@ png_push_process_row(png_structrp png_ptr)
          png_read_filter_row(png_ptr, &row_info, png_ptr->row_buf + 1,
             png_ptr->prev_row + 1, png_ptr->row_buf[0]);
       else
-         png_error(png_ptr, "bad adaptive filter value");
+         png_warning(png_ptr, "pngpread: bad adaptive filter value");
    }
 
    /* libpng 1.5.6: the following line was copying png_ptr->rowbytes before

--- a/pngread.c
+++ b/pngread.c
@@ -539,7 +539,7 @@ png_read_row(png_structrp png_ptr, png_bytep row, png_bytep dsp_row)
          png_read_filter_row(png_ptr, &row_info, png_ptr->row_buf + 1,
             png_ptr->prev_row + 1, png_ptr->row_buf[0]);
       else
-         png_error(png_ptr, "bad adaptive filter value");
+         png_warning(png_ptr, "pngread: bad adaptive filter value");
    }
 
    /* libpng 1.5.6: the following line was copying png_ptr->rowbytes before


### PR DESCRIPTION
Need to change errors to warnings to read sample file with this code:

https://github.com/covictory/pngdump

https://github.com/covictory/pngdump/blob/master/testsite/cxr16bit.png